### PR TITLE
Load YAML properly by requiring it

### DIFF
--- a/lib/nark.rb
+++ b/lib/nark.rb
@@ -5,6 +5,7 @@ require 'nark/exceptions'
 require 'nark/plugin'
 require 'nark/report_broker'
 require 'nark/configuration'
+require 'yaml'
 
 #
 # This middleware is the basis of all tracking via rack middleware.


### PR DESCRIPTION
One of the specs was failing on my local machine because
YAML was an uninitialized constant. By explicitly requiring
it I fixed the issue.
